### PR TITLE
ath79/mikrotik: create shared device definitions for nor and nand

### DIFF
--- a/target/linux/ath79/image/common-mikrotik.mk
+++ b/target/linux/ath79/image/common-mikrotik.mk
@@ -4,3 +4,17 @@ define Device/mikrotik
 	KERNEL := kernel-bin | append-dtb | lzma | loader-kernel
 	KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel
 endef
+
+define Device/mikrotik_nor
+  $(Device/mikrotik)
+  IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | \
+	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | \
+	append-metadata | check-size
+endef
+
+define Device/mikrotik_nand
+  $(Device/mikrotik)
+  IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 2048 -e -c | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+  DEVICE_PACKAGES := nand-utils
+endef

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -1,36 +1,28 @@
 include ./common-mikrotik.mk
 
 define Device/mikrotik_routerboard-493g
-  $(Device/mikrotik)
+  $(Device/mikrotik_nand)
   SOC := ar7161
   DEVICE_MODEL := RouterBOARD 493G
-  IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 2048 -e -c | \
-	sysupgrade-tar kernel=$$$$@ | append-metadata
-  DEVICE_PACKAGES += kmod-usb-ohci kmod-usb2 nand-utils
+  DEVICE_PACKAGES += kmod-usb-ohci kmod-usb2
   SUPPORTED_DEVICES += rb-493g
 endef
 TARGET_DEVICES += mikrotik_routerboard-493g
 
 define Device/mikrotik_routerboard-922uags-5hpacd
-  $(Device/mikrotik)
+  $(Device/mikrotik_nand)
   SOC := qca9558
   DEVICE_MODEL := RouterBOARD 922UAGS-5HPacD
-  IMAGE/sysupgrade.bin = append-kernel | kernel2minor -s 2048 -e -c | \
-	sysupgrade-tar kernel=$$$$@ | append-metadata
-  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct \
-	kmod-usb2 nand-utils
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
   SUPPORTED_DEVICES += rb-922uags-5hpacd
 endef
 TARGET_DEVICES += mikrotik_routerboard-922uags-5hpacd
 
 define Device/mikrotik_routerboard-wap-g-5hact2hnd
-  $(Device/mikrotik)
+  $(Device/mikrotik_nor)
   SOC := qca9556
   DEVICE_MODEL := RouterBOARD wAP G-5HacT2HnD (wAP AC)
   IMAGE_SIZE := 16256k
-  IMAGE/sysupgrade.bin := append-kernel | kernel2minor -s 1024 -e | \
-	pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | \
-	append-metadata | check-size
   DEVICE_PACKAGES += kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
   SUPPORTED_DEVICES += rb-wapg-5hact2hnd
 endef


### PR DESCRIPTION
Move the image preparation and nand-utils package selection into
common device definitions for NOR/NAND devices.

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
